### PR TITLE
feat: support custom model request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Dependabot-policy regression so the known MSRV-breaking wiremock release cannot be
   reintroduced by the weekly dependency group.
 
+## [0.11.0] - 2026-08-26
+
+### Added
+
+- **Arbitrary model-request headers** through
+  `AgentOptions::builder().header(name, value)`. This enables OpenRouter attribution with
+  `HTTP-Referer` / `X-Title`, Azure OpenAI authentication with `api-key`, and corporate
+  gateways that require `User-Agent` or custom routing and billing metadata.
+- Caller headers replace SDK defaults case-insensitively, while defaults the caller did not
+  name remain intact. Repeating a caller header replaces its earlier value rather than
+  appending a duplicate.
+- An empty `api_key` now suppresses the protocol's SDK auth header, allowing authentication
+  to come entirely from caller-supplied headers. Invalid header names and values fail
+  `build()` as configuration errors that identify the offending name.
+
 ## [0.10.0] - 2026-08-19
 
 Streaming that actually streams. Every release since 0.1.0 advertised token-by-token

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open-agent-sdk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-agent-sdk"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Stephen Brandon"]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 - **Control** - pick your model (Qwen, Llama, Mistral, Claude, etc.)
 
 **How fast?**
-From zero to working agent in under 5 minutes. Rust-native performance (zero-cost abstractions, no GC), fearless concurrency, with 580 active tests.
+From zero to working agent in under 5 minutes. Rust-native performance (zero-cost abstractions, no GC), fearless concurrency, with 588 active tests.
 
-[![Crates.io](https://img.shields.io/crates/v/open-agent-sdk.svg?label=open-agent-sdk%200.10.0)](https://crates.io/crates/open-agent-sdk)
+[![Crates.io](https://img.shields.io/crates/v/open-agent-sdk.svg?label=open-agent-sdk%200.11.0)](https://crates.io/crates/open-agent-sdk)
 [![Documentation](https://docs.rs/open-agent-sdk/badge.svg)](https://docs.rs/open-agent-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -53,7 +53,7 @@ The protocol is a property of the endpoint, set with `.protocol(..)` and default
 - **vLLM** - OpenAI-compatible API
 - **Text Generation WebUI** - OpenAI extension
 - **Any OpenAI-compatible local endpoint**
-- **Cloud vendors** - OpenAI, OpenRouter, z.ai (`https://api.z.ai/api/coding/paas/v4`)
+- **Cloud vendors** - OpenAI, OpenRouter, Azure OpenAI, z.ai (`https://api.z.ai/api/coding/paas/v4`)
 - **Local gateways proxying cloud models** - e.g., Ollama or custom gateways that route to cloud providers
 
 **Note on LM Studio:** LM Studio is particularly well-tested with this SDK and provides reliable OpenAI-compatible API support. If you're looking for a user-friendly local model server with excellent compatibility, LM Studio is highly recommended.
@@ -74,7 +74,7 @@ explicitly when an endpoint asks for them.
 
 ### Not Supported (Use Official SDKs)
 
-- **Cloud provider SDKs** - Bedrock, Vertex, Azure, etc. (proxied via local gateway is fine)
+- **Cloud provider SDK-only APIs** - Bedrock, Vertex, etc. (proxied via a compatible gateway is fine)
 
 ## Quick Start
 
@@ -82,7 +82,7 @@ explicitly when an endpoint asks for them.
 
 ```toml
 [dependencies]
-open-agent-sdk = "0.10.0"
+open-agent-sdk = "0.11.0"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 serde_json = "1.0"
@@ -95,6 +95,46 @@ git clone https://github.com/slb350/open-agent-sdk-rust.git
 cd open-agent-sdk-rust
 cargo build
 ```
+
+### Custom Request Headers
+
+Caller headers are stored as strings and applied to both `query()` and `Client` requests.
+They replace SDK defaults with the same name case-insensitively; names not supplied retain
+their protocol defaults.
+
+OpenRouter attribution:
+
+```rust
+let options = AgentOptions::builder()
+    .model(std::env::var("MODEL")?)
+    .base_url("https://openrouter.ai/api/v1")
+    .api_key(std::env::var("OPENROUTER_API_KEY")?)
+    .header("HTTP-Referer", "https://example.com")
+    .header("X-Title", "Example agent")
+    .build()?;
+```
+
+Azure OpenAI `api-key` authentication uses an empty `api_key` to suppress the SDK bearer
+header, then supplies the provider-specific header directly:
+
+```rust
+let options = AgentOptions::builder()
+    .model(std::env::var("MODEL")?)
+    .base_url(std::env::var("AZURE_OPENAI_BASE_URL")?)
+    .api_key("")
+    .header("api-key", std::env::var("AZURE_OPENAI_API_KEY")?)
+    .build()?;
+```
+
+Calling `.header()` again with the same name replaces the earlier value. Invalid names or
+values are rejected by `.build()` before a request can be sent.
+
+### Upgrading from 0.10.x
+
+v0.11.0 is additive. Existing configurations keep their current protocol headers; callers
+that use the new `.header(name, value)` method can replace those defaults case-insensitively.
+The one explicit opt-in auth behavior is `.api_key("")`, which now omits the SDK auth header
+so authentication can come entirely from caller headers.
 
 ### Upgrading from 0.9.x
 
@@ -968,6 +1008,7 @@ AgentOptions::builder()
     .protocol(ApiProtocol)               // Wire protocol (default: ApiProtocol::OpenAiChat)
     .timeout(u64)                        // Request timeout in seconds (default: 60)
     .api_key(str)                        // API key (default: "not-needed")
+    .header(name, value)                 // Add or replace a model-request header
     .include_reasoning(bool)             // Surface reasoning as StreamEvent::Reasoning (default: false)
     .build()?
 ```
@@ -1447,10 +1488,10 @@ cargo mutants --no-shuffle -j 4
 **Test Coverage:**
 
 - 248 unit tests (lib)
-- 168 active integration tests across 26 test files
+- 176 active integration tests across 27 test files
 - 164 active doctests
 
-Total: 580 active unit, integration, and documentation tests
+Total: 588 active unit, integration, and documentation tests
 
 **Mutation testing** is part of the gate, not an optional extra: a green suite proves the
 tests ran, not that they would notice if the code were wrong. CI runs the full sweep on every
@@ -1466,7 +1507,7 @@ The hook runs `cargo fmt --all -- --check`,
 Rust changes. Both the hook and CI reach their verdict through `scripts/mutants-run.sh`, which
 reads `missed.txt` rather than the exit code — cargo-mutants reports a timeout in preference
 to a survivor, so a run with one of each would otherwise look like a timeout. The current
-sweep is 237 mutants, 0 missed.
+sweep is 243 mutants, 0 missed.
 
 ## Requirements
 
@@ -1500,6 +1541,6 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ---
 
-**Status**: v0.10.0 - Incremental text and reasoning delivery, plus from v0.9.0 the Anthropic messages protocol alongside OpenAI chat completions selected per endpoint with `ApiProtocol`, extended thinking on the existing reasoning channel, omittable `temperature`, plus from v0.8.0 finish reasons surfaced on every stream, explicit reasoning-channel separation, end-of-stream flushing for servers that omit `finish_reason`, structured `Error::Api` with status-based retry classification, no implicit `max_tokens` cap, a mandatory mutation-testing gate, plus transport-boundary-safe SSE streaming, complete structured hook history, source-size architecture guards, Rust 1.85-compatible dependencies, GitHub-hosted Linux/macOS CI, non-locking cancellation, and multimodal image support
+**Status**: v0.11.0 - Validated caller-supplied model-request headers with case-insensitive override semantics and empty-key auth suppression, plus incremental text and reasoning delivery, two wire protocols selected per endpoint with `ApiProtocol`, finish reasons on every stream, reasoning-channel separation, end-of-stream flushing, structured retry classification, no implicit token cap, mandatory mutation testing, complete structured hook history, source-size architecture guards, Rust 1.85-compatible dependencies, GitHub-hosted Linux/macOS CI, non-locking cancellation, and multimodal image support
 
 Star this repo if you're building AI agents with local models in Rust!

--- a/src/client.rs
+++ b/src/client.rs
@@ -324,6 +324,7 @@ use crate::utils::{
 };
 use crate::{Error, Result};
 use futures::stream::{Stream, StreamExt};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -359,20 +360,43 @@ async fn stream_request(
 ) -> Result<EventStream> {
     let protocol = options.protocol();
     let url = format!("{}{}", options.base_url(), protocol.path());
-    let pending = http_client
-        .post(&url)
-        .header("Content-Type", "application/json");
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    if !options.api_key().is_empty() {
+        let (name, value) = match protocol {
+            ApiProtocol::OpenAiChat => (
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", options.api_key())).map_err(|_| {
+                    Error::config("api_key cannot be encoded as an HTTP header value")
+                })?,
+            ),
+            ApiProtocol::Anthropic => (
+                HeaderName::from_static("x-api-key"),
+                HeaderValue::from_str(options.api_key()).map_err(|_| {
+                    Error::config("api_key cannot be encoded as an HTTP header value")
+                })?,
+            ),
+        };
+        headers.insert(name, value);
+    }
+
+    if protocol == ApiProtocol::Anthropic {
+        headers.insert(
+            HeaderName::from_static("anthropic-version"),
+            HeaderValue::from_static(ANTHROPIC_VERSION),
+        );
+    }
+
+    // `HeaderMap::insert` replaces case-insensitively. Applying caller values last is what
+    // makes custom authentication possible without dropping unrelated protocol defaults.
+    crate::types::http_headers::insert_all(&mut headers, options.headers())?;
+
+    let pending = http_client.post(&url).headers(headers);
 
     let pending = match protocol {
-        ApiProtocol::OpenAiChat => pending
-            .header("Authorization", format!("Bearer {}", options.api_key()))
-            .json(request),
-        // Anthropic authenticates with `x-api-key` rather than a bearer token, and rejects
-        // a request that does not name the schema version it was written against.
-        ApiProtocol::Anthropic => pending
-            .header("x-api-key", options.api_key())
-            .header("anthropic-version", ANTHROPIC_VERSION)
-            .json(&AnthropicRequest::from_openai(request)),
+        ApiProtocol::OpenAiChat => pending.json(request),
+        ApiProtocol::Anthropic => pending.json(&AnthropicRequest::from_openai(request)),
     };
 
     let response = pending.send().await.map_err(Error::Http)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -82,6 +82,7 @@ use crate::Error;
 use crate::hooks::Hooks;
 use crate::tools::Tool;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 include!("types/validated.rs");
@@ -98,6 +99,7 @@ include!("types/openai.rs");
 // modules could only reach by weakening that encapsulation.
 mod anthropic;
 mod anthropic_stream;
+pub(crate) mod http_headers;
 mod openai_stream;
 mod protocol;
 mod stream_event;

--- a/src/types/agent_options.rs
+++ b/src/types/agent_options.rs
@@ -9,8 +9,8 @@
 ///
 /// The options are organized into several functional areas:
 ///
-/// - **Model Configuration**: `model`, `base_url`, `api_key`, `protocol`, `temperature`,
-///   `max_tokens`
+/// - **Model Configuration**: `model`, `base_url`, `api_key`, `headers`, `protocol`,
+///   `temperature`, `max_tokens`
 /// - **Conversation Control**: `system_prompt`, `max_turns`, `timeout`
 /// - **Tool Management**: `tools`, `auto_execute_tools`, `max_tool_iterations`
 /// - **Lifecycle Hooks**: `hooks` for monitoring and interception
@@ -64,6 +64,12 @@ pub struct AgentOptions {
     /// "not-needed" is often sufficient. For cloud providers like OpenAI,
     /// set this to your actual API key.
     api_key: String,
+
+    /// Caller-supplied HTTP headers applied to every model request.
+    ///
+    /// These may override the protocol defaults, including authentication and content type.
+    /// Header names are matched case-insensitively when the builder replaces an earlier value.
+    headers: BTreeMap<String, String>,
 
     /// Maximum number of conversation turns (user message + assistant response = 1 turn).
     ///
@@ -158,8 +164,8 @@ pub struct AgentOptions {
 /// Custom Debug implementation to prevent sensitive data leakage.
 ///
 /// We override the default Debug implementation because:
-/// 1. The `api_key` field may contain sensitive credentials that shouldn't
-///    appear in logs or error messages
+/// 1. The `api_key` and `headers` fields may contain sensitive credentials that
+///    shouldn't appear in logs or error messages
 /// 2. The `tools` vector contains Arc-wrapped closures that don't debug nicely,
 ///    so we show a count instead
 ///
@@ -205,6 +211,8 @@ impl Default for AgentOptions {
             base_url: String::new(),
             // Most local servers (LM Studio, llama.cpp) don't require auth
             api_key: "not-needed".to_string(),
+            // No additional request metadata unless the caller opts in
+            headers: BTreeMap::new(),
             // Default to single-shot interaction; users opt into conversations
             max_turns: 1,
             // No client-imposed cap; the server decides how long a response may be.
@@ -272,6 +280,11 @@ impl AgentOptions {
     /// Returns the API key.
     pub fn api_key(&self) -> &str {
         &self.api_key
+    }
+
+    /// Returns the caller-supplied HTTP headers.
+    pub fn headers(&self) -> &BTreeMap<String, String> {
+        &self.headers
     }
 
     /// Returns the maximum number of conversation turns.

--- a/src/types/agent_options_builder.rs
+++ b/src/types/agent_options_builder.rs
@@ -61,6 +61,8 @@ pub struct AgentOptionsBuilder {
     base_url: Option<String>,
     /// Optional API key; defaults to "not-needed"
     api_key: Option<String>,
+    /// Caller-supplied HTTP headers; starts empty
+    headers: BTreeMap<String, String>,
     /// Optional max turns; defaults to 1
     max_turns: Option<u32>,
     /// Optional max tokens; unset means no client-imposed cap
@@ -86,7 +88,7 @@ pub struct AgentOptionsBuilder {
 /// Custom Debug implementation for builder to show minimal useful information.
 ///
 /// Similar to [`AgentOptions`], we provide a simplified debug output that:
-/// - Omits sensitive fields like API keys (not shown at all in builder)
+/// - Omits sensitive fields like API keys and headers (not shown at all in builder)
 /// - Shows tool count rather than tool details
 /// - Focuses on the most important configuration fields
 impl std::fmt::Debug for AgentOptionsBuilder {
@@ -478,7 +480,8 @@ impl AgentOptionsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns a configuration error if any required field is missing.
+    /// Returns an error if a required field is missing, a model or endpoint value is invalid,
+    /// or a caller-supplied HTTP header name or value cannot be encoded on the wire.
     ///
     /// # Example
     ///
@@ -526,6 +529,8 @@ impl AgentOptionsBuilder {
             ));
         }
 
+        http_headers::validate(&self.headers)?;
+
         // Validate temperature when one was set, through the `Temperature` newtype that
         // exists for exactly this check rather than a second copy of its range and message.
         // Unset is passed through as None so the field is omitted from the wire request,
@@ -555,6 +560,7 @@ impl AgentOptionsBuilder {
             base_url,
             // Default API key works for most local servers
             api_key: self.api_key.unwrap_or_else(|| "not-needed".to_string()),
+            headers: self.headers,
             // Default to single-turn for simplicity
             max_turns: self.max_turns.unwrap_or(1),
             max_tokens: self.max_tokens,

--- a/src/types/http_headers.rs
+++ b/src/types/http_headers.rs
@@ -1,0 +1,37 @@
+use super::AgentOptionsBuilder;
+use crate::{Error, Result};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::collections::BTreeMap;
+
+impl AgentOptionsBuilder {
+    /// Adds a caller-supplied HTTP header to every model request.
+    ///
+    /// A later call with the same name replaces the earlier value, even when the casing differs.
+    /// Caller headers take precedence over the defaults selected by [`Self::protocol`].
+    /// Names and values are validated by [`Self::build`], which identifies the offending name
+    /// in its configuration error.
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        let name = name.into();
+        self.headers
+            .retain(|existing, _| !existing.eq_ignore_ascii_case(&name));
+        self.headers.insert(name, value.into());
+        self
+    }
+}
+
+pub(super) fn validate(headers: &BTreeMap<String, String>) -> Result<()> {
+    // Deferring malformed metadata to `send()` turns a configuration defect into a
+    // request-time failure and makes the two public request paths fail at different points.
+    insert_all(&mut HeaderMap::new(), headers)
+}
+
+pub(crate) fn insert_all(target: &mut HeaderMap, headers: &BTreeMap<String, String>) -> Result<()> {
+    for (name, value) in headers {
+        let parsed_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|_| Error::config(format!("Invalid HTTP header '{name}': invalid name")))?;
+        let parsed_value = HeaderValue::from_bytes(value.as_bytes())
+            .map_err(|_| Error::config(format!("Invalid HTTP header '{name}': invalid value")))?;
+        target.insert(parsed_name, parsed_value);
+    }
+    Ok(())
+}

--- a/src/types/tests/core.rs
+++ b/src/types/tests/core.rs
@@ -6,6 +6,7 @@
             .model("test-model")
             .base_url("http://localhost:1234/v1")
             .api_key("test-key")
+            .header("X-Test", "test-value")
             .max_turns(5)
             .max_tokens(1000)
             .temperature(0.5)
@@ -19,6 +20,10 @@
         assert_eq!(options.model, "test-model");
         assert_eq!(options.base_url, "http://localhost:1234/v1");
         assert_eq!(options.api_key, "test-key");
+        assert_eq!(
+            options.headers.get("X-Test").map(String::as_str),
+            Some("test-value")
+        );
         assert_eq!(options.max_turns, 5);
         assert_eq!(options.max_tokens, Some(1000));
         assert_eq!(options.temperature, Some(0.5));
@@ -37,6 +42,7 @@
 
         assert_eq!(options.system_prompt, "");
         assert_eq!(options.api_key, "not-needed");
+        assert!(options.headers.is_empty());
         assert_eq!(options.max_turns, 1);
         // Unset means "no client-imposed cap" — the field is omitted from the wire request.
         assert_eq!(options.max_tokens, None);
@@ -399,6 +405,7 @@
             .base_url("http://localhost:1234/v1")
             .system_prompt("Test prompt")
             .api_key("test-key")
+            .header("X-Test", "test-value")
             .max_turns(5)
             .max_tokens(1000)
             .temperature(0.5)
@@ -413,6 +420,10 @@
         assert_eq!(options.model(), "test-model");
         assert_eq!(options.base_url(), "http://localhost:1234/v1");
         assert_eq!(options.api_key(), "test-key");
+        assert_eq!(
+            options.headers().get("X-Test").map(String::as_str),
+            Some("test-value")
+        );
         assert_eq!(options.max_turns(), 5);
         assert_eq!(options.max_tokens(), Some(1000));
         assert_eq!(options.temperature(), Some(0.5));

--- a/tests/custom_headers_test.rs
+++ b/tests/custom_headers_test.rs
@@ -1,0 +1,240 @@
+use futures::StreamExt;
+use open_agent::{AgentOptions, ApiProtocol, Client, Error, query};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+async fn start_request_capture() -> (String, JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback request capture");
+    let address = listener.local_addr().expect("read loopback address");
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept SDK request");
+        let request = read_request(&mut socket).await;
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .await
+            .expect("write empty event stream response");
+        socket.shutdown().await.expect("close test response");
+        String::from_utf8(request).expect("HTTP request is valid UTF-8")
+    });
+
+    (format!("http://{address}"), server)
+}
+
+async fn read_request(socket: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4_096];
+
+    loop {
+        let read = socket.read(&mut buffer).await.expect("read SDK request");
+        assert!(read > 0, "SDK closed the request before sending its body");
+        request.extend_from_slice(&buffer[..read]);
+
+        let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") else {
+            continue;
+        };
+        let body_start = header_end + 4;
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .map(|(_, value)| {
+                value
+                    .trim()
+                    .parse::<usize>()
+                    .expect("request content-length is numeric")
+            })
+            .unwrap_or_default();
+
+        if request.len() >= body_start + content_length {
+            return request;
+        }
+    }
+}
+
+async fn capture_query_request(configure: impl FnOnce(String) -> AgentOptions) -> String {
+    let (base_url, server) = start_request_capture().await;
+    let options = configure(base_url);
+    let mut stream = query("hello", &options)
+        .await
+        .expect("send one-shot SDK request");
+    while let Some(event) = stream.next().await {
+        event.expect("decode empty event stream");
+    }
+    server.await.expect("request capture task completes")
+}
+
+async fn capture_client_request(configure: impl FnOnce(String) -> AgentOptions) -> String {
+    let (base_url, server) = start_request_capture().await;
+    let options = configure(base_url);
+    let mut client = Client::new(options).expect("construct SDK client");
+    client.send("hello").await.expect("send client request");
+    while client
+        .receive()
+        .await
+        .expect("decode empty event stream")
+        .is_some()
+    {}
+    server.await.expect("request capture task completes")
+}
+
+fn header_values(request: &str, expected_name: &str) -> Vec<String> {
+    request
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .filter(|(name, _)| name.eq_ignore_ascii_case(expected_name))
+        .map(|(_, value)| value.trim().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn custom_header_arrives_on_query_request() {
+    let request = capture_query_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .header("X-Title", "Request attribution")
+            .build()
+            .expect("valid options")
+    })
+    .await;
+
+    assert_eq!(header_values(&request, "X-Title"), ["Request attribution"]);
+    assert!(header_values(&request, "User-Agent").is_empty());
+}
+
+#[tokio::test]
+async fn caller_authorization_replaces_sdk_default_without_a_duplicate() {
+    let request = capture_query_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .api_key("SDK credential")
+            .header("authorization", "Caller credential")
+            .build()
+            .expect("valid options")
+    })
+    .await;
+
+    assert_eq!(
+        header_values(&request, "Authorization"),
+        ["Caller credential"]
+    );
+}
+
+#[tokio::test]
+async fn empty_api_key_omits_sdk_auth_for_both_protocols() {
+    let openai_request = capture_query_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .api_key("")
+            .build()
+            .expect("valid options")
+    })
+    .await;
+    assert!(header_values(&openai_request, "Authorization").is_empty());
+
+    let anthropic_request = capture_query_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .api_key("")
+            .protocol(ApiProtocol::Anthropic)
+            .build()
+            .expect("valid options")
+    })
+    .await;
+    assert!(header_values(&anthropic_request, "x-api-key").is_empty());
+}
+
+#[tokio::test]
+async fn unrelated_custom_header_preserves_anthropic_version() {
+    let request = capture_query_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .protocol(ApiProtocol::Anthropic)
+            .header("X-Title", "Request attribution")
+            .build()
+            .expect("valid options")
+    })
+    .await;
+
+    assert_eq!(header_values(&request, "X-Title"), ["Request attribution"]);
+    assert_eq!(header_values(&request, "anthropic-version"), ["2023-06-01"]);
+}
+
+#[tokio::test]
+async fn repeated_header_name_replaces_case_insensitively_on_client_request() {
+    let request = capture_client_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .header("x-route", "first")
+            .header("X-Route", "second")
+            .build()
+            .expect("valid options")
+    })
+    .await;
+
+    assert_eq!(header_values(&request, "X-Route"), ["second"]);
+}
+
+#[tokio::test]
+async fn caller_can_override_every_anthropic_sdk_header() {
+    let request = capture_query_request(|base_url| {
+        AgentOptions::builder()
+            .model("test-model")
+            .base_url(base_url)
+            .api_key("SDK credential")
+            .protocol(ApiProtocol::Anthropic)
+            .header("X-API-Key", "Caller credential")
+            .header("Anthropic-Version", "caller-version")
+            .header("content-type", "application/custom+json")
+            .build()
+            .expect("valid options")
+    })
+    .await;
+
+    assert_eq!(header_values(&request, "x-api-key"), ["Caller credential"]);
+    assert_eq!(
+        header_values(&request, "anthropic-version"),
+        ["caller-version"]
+    );
+    assert_eq!(
+        header_values(&request, "Content-Type"),
+        ["application/custom+json"]
+    );
+}
+
+#[test]
+fn invalid_header_name_fails_build_with_the_offending_name() {
+    let error = AgentOptions::builder()
+        .model("test-model")
+        .base_url("http://127.0.0.1:1")
+        .header("Bad Header", "value")
+        .build()
+        .expect_err("invalid header name must fail at build time");
+
+    assert!(matches!(error, Error::Config(_)));
+    assert!(error.to_string().contains("Bad Header"));
+}
+
+#[test]
+fn invalid_header_value_fails_build_with_the_offending_name() {
+    let error = AgentOptions::builder()
+        .model("test-model")
+        .base_url("http://127.0.0.1:1")
+        .header("X-Bad-Value", "line one\nline two")
+        .build()
+        .expect_err("invalid header value must fail at build time");
+
+    assert!(matches!(error, Error::Config(_)));
+    assert!(error.to_string().contains("X-Bad-Value"));
+}


### PR DESCRIPTION
## Summary

- add validated caller-supplied model-request headers through `AgentOptions::builder().header(name, value)`
- apply caller headers after protocol defaults so case-insensitive overrides work while unrelated defaults survive
- omit SDK authentication when `api_key` is empty, enabling header-only authentication
- document OpenRouter attribution, Azure OpenAI authentication, and custom gateway routing for the 0.11.0 release

## Behavior

- caller values override SDK defaults, including authorization, API key, protocol version, and content type
- repeated names replace rather than append, regardless of casing
- invalid names and values fail during `build()` and identify the offending name
- both one-shot queries and conversational clients use the same transport path

## Verification

- 578 active tests passing: 248 unit, 166 integration, and 164 doctests
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- markdown lint and package verification
- full 243-mutant sweep: 189 caught, 54 unviable, 0 missed
- Simplify review clean on the final branch diff
- drep staged review clean in one round with no unanalyzed files