### PR TITLE
fix(client): Reject model request redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-08-31
+
 ### Security
 
 - Model requests no longer follow HTTP redirects, including same-origin redirects. Custom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Model requests no longer follow HTTP redirects, including same-origin redirects. Custom
+  headers and other credentials are sent only to the configured origin, while any `30x`
+  response remains visible through the existing API-status error path.
+
+### Tests
+
+- Added raw loopback regressions for both `query()` and `Client` proving a redirect target is
+  never contacted and cannot receive a caller-supplied credential header.
+
 ## [0.11.1] - 2026-08-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open-agent-sdk"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-agent-sdk"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Stephen Brandon"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ let options = AgentOptions::builder()
 Calling `.header()` again with the same name replaces the earlier value. Invalid names or
 values are rejected by `.build()` before a request can be sent.
 
+Custom headers are sent only to the configured model origin. Model requests deliberately do
+not follow HTTP redirects, including same-origin redirects; any `30x` response surfaces through
+the normal API-status error path. Set `base_url` to the exact destination that should receive
+the request and its credentials.
+
 ### Upgrading from 0.10.x
 
 v0.11.0 is additive. Existing configurations keep their current protocol headers; callers

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 - **Control** - pick your model (Qwen, Llama, Mistral, Claude, etc.)
 
 **How fast?**
-From zero to working agent in under 5 minutes. Rust-native performance (zero-cost abstractions, no GC), fearless concurrency, with 592 active tests.
+From zero to working agent in under 5 minutes. Rust-native performance (zero-cost abstractions, no GC), fearless concurrency, with 595 active tests.
 
-[![Crates.io](https://img.shields.io/crates/v/open-agent-sdk.svg?label=open-agent-sdk%200.11.1)](https://crates.io/crates/open-agent-sdk)
+[![Crates.io](https://img.shields.io/crates/v/open-agent-sdk.svg?label=open-agent-sdk%200.11.2)](https://crates.io/crates/open-agent-sdk)
 [![Documentation](https://docs.rs/open-agent-sdk/badge.svg)](https://docs.rs/open-agent-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -82,7 +82,7 @@ explicitly when an endpoint asks for them.
 
 ```toml
 [dependencies]
-open-agent-sdk = "0.11.1"
+open-agent-sdk = "0.11.2"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 serde_json = "1.0"
@@ -1547,6 +1547,6 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ---
 
-**Status**: v0.11.1 - Reproducible published package tests, concurrency-safe mutation infrastructure, non-yanked Rust 1.85-compatible dependencies and current immutable CI pins, plus validated caller-supplied model-request headers, incremental streaming, OpenAI and Anthropic wire protocols, finish reasons, reasoning-channel separation, structured retry classification, context controls, hooks, tools and multimodal image support
+**Status**: v0.11.2 - Model requests deliberately reject redirects so custom headers and other credentials are sent only to the configured origin, plus validated caller-supplied model-request headers, incremental streaming, OpenAI and Anthropic wire protocols, finish reasons, reasoning-channel separation, structured retry classification, context controls, hooks, tools and multimodal image support
 
 Star this repo if you're building AI agents with local models in Rust!

--- a/src/client.rs
+++ b/src/client.rs
@@ -348,6 +348,17 @@ fn serialize_history_snapshot(history: &[Message]) -> Result<Vec<serde_json::Val
 /// this SDK was written against, so it changes when the code does.
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 
+/// Builds the shared HTTP-client policy for model requests.
+///
+/// Redirects are rejected even when they stay on the same origin. The configured base URL
+/// names the exact model endpoint, and caller-supplied credentials must never be replayed to a
+/// destination selected by an HTTP response.
+fn model_http_client_builder(options: &AgentOptions) -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(options.timeout()))
+        .redirect(reqwest::redirect::Policy::none())
+}
+
 /// Sends the request over whichever protocol `options` selects and returns its event stream.
 ///
 /// The one place the two protocols differ. Both call sites build the same protocol-neutral

--- a/src/client/query.rs
+++ b/src/client/query.rs
@@ -209,8 +209,7 @@ pub type EventStream = Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>;
 pub async fn query(prompt: &str, options: &AgentOptions) -> Result<EventStream> {
     // Create HTTP client with configured timeout
     // The timeout applies to the entire request, not individual chunks
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(options.timeout()))
+    let client = model_http_client_builder(options)
         .build()
         .map_err(Error::Http)?;
 

--- a/src/client/setup.rs
+++ b/src/client/setup.rs
@@ -31,8 +31,7 @@ impl Client {
     pub fn new(options: AgentOptions) -> Result<Self> {
         // Build HTTP client with configured timeout
         // This client is reused across all requests for connection pooling
-        let http_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(options.timeout()))
+        let http_client = model_http_client_builder(&options)
             .build()
             .map_err(|e| Error::config(format!("Failed to build HTTP client: {}", e)))?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,8 +8,53 @@
 
 use futures::StreamExt;
 use open_agent::{AgentOptions, ContentBlock, FinishReason, Message, StreamEvent, query};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Reads one complete HTTP request, including a body identified by `Content-Length`.
+pub async fn read_request(socket: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4_096];
+
+    loop {
+        let read = socket.read(&mut buffer).await.expect("read SDK request");
+        assert!(read > 0, "SDK closed the request before sending its body");
+        request.extend_from_slice(&buffer[..read]);
+
+        let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") else {
+            continue;
+        };
+        let body_start = header_end + 4;
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .map(|(_, value)| {
+                value
+                    .trim()
+                    .parse::<usize>()
+                    .expect("request content-length is numeric")
+            })
+            .unwrap_or_default();
+
+        if request.len() >= body_start + content_length {
+            return request;
+        }
+    }
+}
+
+/// Returns every value for `expected_name`, matching the HTTP header name case-insensitively.
+pub fn header_values(request: &str, expected_name: &str) -> Vec<String> {
+    request
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .filter(|(name, _)| name.eq_ignore_ascii_case(expected_name))
+        .map(|(_, value)| value.trim().to_string())
+        .collect()
+}
 
 /// Starts a mock server that answers the chat-completions endpoint with `body` as an SSE
 /// stream.

--- a/tests/custom_headers_test.rs
+++ b/tests/custom_headers_test.rs
@@ -1,7 +1,10 @@
+mod common;
+
+use common::{header_values, read_request};
 use futures::StreamExt;
 use open_agent::{AgentOptions, ApiProtocol, Client, Error, query};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
 async fn start_request_capture() -> (String, JoinHandle<String>) {
@@ -23,38 +26,6 @@ async fn start_request_capture() -> (String, JoinHandle<String>) {
     });
 
     (format!("http://{address}"), server)
-}
-
-async fn read_request(socket: &mut TcpStream) -> Vec<u8> {
-    let mut request = Vec::new();
-    let mut buffer = [0_u8; 4_096];
-
-    loop {
-        let read = socket.read(&mut buffer).await.expect("read SDK request");
-        assert!(read > 0, "SDK closed the request before sending its body");
-        request.extend_from_slice(&buffer[..read]);
-
-        let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") else {
-            continue;
-        };
-        let body_start = header_end + 4;
-        let headers = String::from_utf8_lossy(&request[..header_end]);
-        let content_length = headers
-            .lines()
-            .filter_map(|line| line.split_once(':'))
-            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
-            .map(|(_, value)| {
-                value
-                    .trim()
-                    .parse::<usize>()
-                    .expect("request content-length is numeric")
-            })
-            .unwrap_or_default();
-
-        if request.len() >= body_start + content_length {
-            return request;
-        }
-    }
 }
 
 async fn capture_query_request(configure: impl FnOnce(String) -> AgentOptions) -> String {
@@ -81,15 +52,6 @@ async fn capture_client_request(configure: impl FnOnce(String) -> AgentOptions) 
         .is_some()
     {}
     server.await.expect("request capture task completes")
-}
-
-fn header_values(request: &str, expected_name: &str) -> Vec<String> {
-    request
-        .lines()
-        .filter_map(|line| line.split_once(':'))
-        .filter(|(name, _)| name.eq_ignore_ascii_case(expected_name))
-        .map(|(_, value)| value.trim().to_string())
-        .collect()
 }
 
 #[tokio::test]

--- a/tests/redirect_policy_test.rs
+++ b/tests/redirect_policy_test.rs
@@ -1,0 +1,191 @@
+mod common;
+
+use common::{header_values, read_request};
+use open_agent::{AgentOptions, Client, Error, query};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, timeout};
+
+const SENTINEL_TOKEN: &str = "tenant-secret-must-stay-at-origin";
+const REDIRECT_BODY: &str = "redirects are not model responses";
+
+fn redirect_response(address: std::net::SocketAddr) -> String {
+    format!(
+        "HTTP/1.1 307 Temporary Redirect\r\nlocation: http://{address}/redirected\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{REDIRECT_BODY}",
+        REDIRECT_BODY.len()
+    )
+}
+
+async fn start_redirect_pair() -> (String, JoinHandle<String>, JoinHandle<Option<String>>) {
+    let target_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback redirect target");
+    let target_address = target_listener
+        .local_addr()
+        .expect("read redirect target address");
+    let target = tokio::spawn(async move {
+        let accepted = timeout(Duration::from_secs(1), target_listener.accept()).await;
+        let (mut socket, _) = match accepted {
+            Err(_) => return None,
+            Ok(Ok(connection)) => connection,
+            Ok(Err(error)) => panic!("accept redirect target request: {error}"),
+        };
+
+        let request = timeout(Duration::from_secs(1), read_request(&mut socket))
+            .await
+            .expect("redirect target request is complete before timeout");
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .await
+            .expect("write redirect target response");
+        socket.shutdown().await.expect("close redirect target");
+        Some(String::from_utf8(request).expect("redirected request is valid UTF-8"))
+    });
+
+    let origin_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback origin");
+    let origin_address = origin_listener.local_addr().expect("read origin address");
+    let origin = tokio::spawn(async move {
+        let (mut socket, _) = origin_listener
+            .accept()
+            .await
+            .expect("accept origin request");
+        let request = read_request(&mut socket).await;
+        let response = redirect_response(target_address);
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write origin redirect response");
+        socket.shutdown().await.expect("close origin response");
+        String::from_utf8(request).expect("origin request is valid UTF-8")
+    });
+
+    (format!("http://{origin_address}"), origin, target)
+}
+
+async fn start_same_origin_redirect() -> (String, JoinHandle<(String, Option<String>)>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback origin");
+    let address = listener.local_addr().expect("read origin address");
+    let server = tokio::spawn(async move {
+        let (mut origin_socket, _) = listener.accept().await.expect("accept origin request");
+        let origin_request = read_request(&mut origin_socket).await;
+        let response = redirect_response(address);
+        origin_socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write same-origin redirect response");
+        origin_socket
+            .shutdown()
+            .await
+            .expect("close same-origin response");
+
+        let redirected_request = match timeout(Duration::from_secs(1), listener.accept()).await {
+            Err(_) => None,
+            Ok(Ok((mut socket, _))) => {
+                let request = timeout(Duration::from_secs(1), read_request(&mut socket))
+                    .await
+                    .expect("same-origin redirect request is complete before timeout");
+                Some(
+                    String::from_utf8(request)
+                        .expect("same-origin redirected request is valid UTF-8"),
+                )
+            }
+            Ok(Err(error)) => panic!("accept same-origin redirect request: {error}"),
+        };
+
+        (
+            String::from_utf8(origin_request).expect("origin request is valid UTF-8"),
+            redirected_request,
+        )
+    });
+
+    (format!("http://{address}"), server)
+}
+
+fn assert_redirect_not_contacted(target_request: Option<&str>) {
+    if let Some(request) = target_request {
+        assert_eq!(header_values(request, "X-Tenant-Token"), [SENTINEL_TOKEN]);
+        panic!("redirect target received the model request:\n{request}");
+    }
+}
+
+fn assert_origin_redirect_error(error: Option<Error>) {
+    let error = error.expect("origin 307 must surface as an API error");
+    assert_eq!(error.status_code(), Some(307));
+    assert!(
+        error.to_string().contains(REDIRECT_BODY),
+        "API error must retain the origin response body: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_rejects_redirect_without_forwarding_custom_headers() {
+    let (base_url, origin, target) = start_redirect_pair().await;
+    let options = AgentOptions::builder()
+        .model("test-model")
+        .base_url(base_url)
+        .header("X-Tenant-Token", SENTINEL_TOKEN)
+        .build()
+        .expect("valid options");
+
+    let error = query("hello", &options).await.err();
+    let origin_request = origin.await.expect("origin task completes");
+    let target_request = target.await.expect("redirect target task completes");
+
+    assert_eq!(
+        header_values(&origin_request, "X-Tenant-Token"),
+        [SENTINEL_TOKEN]
+    );
+    assert_redirect_not_contacted(target_request.as_deref());
+    assert_origin_redirect_error(error);
+}
+
+#[tokio::test]
+async fn client_rejects_redirect_without_forwarding_custom_headers() {
+    let (base_url, origin, target) = start_redirect_pair().await;
+    let options = AgentOptions::builder()
+        .model("test-model")
+        .base_url(base_url)
+        .header("X-Tenant-Token", SENTINEL_TOKEN)
+        .build()
+        .expect("valid options");
+    let mut client = Client::new(options).expect("construct SDK client");
+
+    let error = client.send("hello").await.err();
+    let origin_request = origin.await.expect("origin task completes");
+    let target_request = target.await.expect("redirect target task completes");
+
+    assert_eq!(
+        header_values(&origin_request, "X-Tenant-Token"),
+        [SENTINEL_TOKEN]
+    );
+    assert_redirect_not_contacted(target_request.as_deref());
+    assert_origin_redirect_error(error);
+}
+
+#[tokio::test]
+async fn same_origin_redirect_is_rejected_without_a_second_request() {
+    let (base_url, server) = start_same_origin_redirect().await;
+    let options = AgentOptions::builder()
+        .model("test-model")
+        .base_url(base_url)
+        .header("X-Tenant-Token", SENTINEL_TOKEN)
+        .build()
+        .expect("valid options");
+
+    let error = query("hello", &options).await.err();
+    let (origin_request, redirected_request) = server.await.expect("origin task completes");
+
+    assert_eq!(
+        header_values(&origin_request, "X-Tenant-Token"),
+        [SENTINEL_TOKEN]
+    );
+    assert_redirect_not_contacted(redirected_request.as_deref());
+    assert_origin_redirect_error(error);
+}


### PR DESCRIPTION
## Summary
- disable reqwest redirects for every model-request client
- cover query, Client, cross-origin, and same-origin redirect behavior with raw TCP tests
- retain origin 30x responses through the existing API-status error path
- document the credential-origin invariant and prepare patch release v0.11.2

## Security
Caller-supplied headers such as X-Tenant-Token are sent only to the configured origin. Model requests deliberately follow no redirects.

## Verification
- RED: both public paths contacted the redirect listener and forwarded the sentinel header before the fix
- cargo test --test redirect_policy_test --all-features
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- staged mutation: 1 mutant caught
- full-diff simplify review: clean