### PR TITLE
chore(release): prepare v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve manual tool-result call IDs through OpenAI and Anthropic request translation.
 - Truncate logged image URLs at UTF-8 boundaries and reject non-ASCII Base64 characters.
 - Forward custom mutation-result directories to the remote execution environment.
+- Keep the repository's package-check test out of crate archives so unpacked sources
+  can run their tests without trying to repackage Cargo-generated files.
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-09-05
+
 ### Changed
 
 - Stop running the full `cargo-mutants` sweep for every ordinary CI revision. Added, modified,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Description
 
-A lightweight Rust SDK (v0.11.2 source) for building AI agents with local or cloud LLMs. Speaks two wire protocols: OpenAI chat completions and Anthropic messages, selected per endpoint with `ApiProtocol`. Rust port of the Python open-agent-sdk. Published to crates.io as `open-agent-sdk`.
+A lightweight Rust SDK (v0.11.3 source) for building AI agents with local or cloud LLMs. Speaks two wire protocols: OpenAI chat completions and Anthropic messages, selected per endpoint with `ApiProtocol`. Rust port of the Python open-agent-sdk. Published to crates.io as `open-agent-sdk`.
 
 ## Repository Structure
 
@@ -440,7 +440,7 @@ cargo test --test mutation_ci_scope_test
 - PR benchmarks: compare Criterion results directly against the base commit with a shared target directory; do not restore the obsolete `boa-dev/criterion-compare-action`
 - Coverage reports: use the exact cargo-tarpaulin 0.37.2 LLVM engine in unprivileged containers, but do not import its upstream lockfile while that lock contains vulnerable anyhow 1.0.102; retain the XML with the latest compatible immutable-SHA-pinned `actions/upload-artifact` release (currently v7.0.1) and fail CI when the report is missing
 
-## Security Advisories (resolved in v0.6.5, current v0.11.2)
+## Security Advisories (resolved in v0.6.5, current v0.11.3)
 
 RUSTSEC-2026-0190 and RUSTSEC-2026-0204 resolved:
 
@@ -450,6 +450,12 @@ RUSTSEC-2026-0190 and RUSTSEC-2026-0204 resolved:
 - `futures` raised to `0.3.32`
 
 ## Current Version
+
+**v0.11.3**. Fixes stale client output, failed-stream cleanup, cancellation during automatic
+tool rounds, and manual tool-result call IDs. Image validation and logging handle non-ASCII
+input safely. Token estimation counts serialized tool JSON without allocating temporary
+strings. The cleanup removes duplicate tests, unused dependencies, and repeated documentation;
+public signatures and defaults remain unchanged. See CHANGELOG.md.
 
 **v0.11.2**. Model requests deliberately reject all HTTP redirects, including same-origin
 redirects, so custom headers and other credentials are sent only to the exact configured

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,6 +383,7 @@ cargo test --test mutation_ci_scope_test
 - `add_tool_result` retains structured `ToolResultBlock` history, including the call ID; never convert it to a plain text block before request translation.
 - `max_turns` is a retained, inert compatibility value. It does not limit Client conversations or tool rounds; `max_tool_iterations` controls automatic tool rounds. Do not silently implement a new turn limit or remove the public setter/getter in a cleanup.
 - Library Tokio features are minimal; test and example runtime features belong in dev-dependencies. Do not reintroduce unused direct dependencies.
+- Package verification is a repository-only test: exclude `tests/package_manifest_test.rs` from crate archives. Validate an unpacked archive's test suite with a separate target directory so Cargo cannot reuse binaries carrying another checkout's `CARGO_MANIFEST_DIR`.
 - Token estimates count tool JSON through its existing `Display` serializer into a byte counter. Preserve JSON escaping and UTF-8 byte lengths without allocating strings solely to measure them.
 
 - **TDD**: Write failing tests first, implement, refactor, commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open-agent-sdk"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "base64 0.23.1",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ exclude = [
     "tests/fixtures/",
     "tests/mutation_scripts_test.rs",
     "tests/mutation_transport_scripts_test.rs",
+    "tests/package_manifest_test.rs",
     "tests/support/",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-agent-sdk"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Stephen Brandon"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **Local or hosted** - run on your own hardware at no API cost and with no data leaving the machine, or point it at a vendor
 - **Control** - pick your model (Qwen, Llama, Mistral, Claude, etc.)
 
-[![Crates.io](https://img.shields.io/crates/v/open-agent-sdk.svg?label=open-agent-sdk%200.11.2)](https://crates.io/crates/open-agent-sdk)
+[![Crates.io](https://img.shields.io/crates/v/open-agent-sdk.svg?label=open-agent-sdk%200.11.3)](https://crates.io/crates/open-agent-sdk)
 [![Documentation](https://docs.rs/open-agent-sdk/badge.svg)](https://docs.rs/open-agent-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -79,7 +79,7 @@ explicitly when an endpoint asks for them.
 
 ```toml
 [dependencies]
-open-agent-sdk = "0.11.2"
+open-agent-sdk = "0.11.3"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 serde_json = "1.0"
@@ -1521,6 +1521,6 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ---
 
-**Status**: v0.11.2 - Model requests deliberately reject redirects so custom headers and other credentials are sent only to the configured origin, plus validated caller-supplied model-request headers, incremental streaming, OpenAI and Anthropic wire protocols, finish reasons, reasoning-channel separation, structured retry classification, context controls, hooks, tools and multimodal image support
+**Status**: v0.11.3 - Fixes client stream cleanup, cancellation, and manual tool-result history; validates image inputs safely; and speeds up tool token estimation. Public signatures and defaults remain unchanged.
 
 Star this repo if you're building AI agents with local models in Rust!

--- a/tests/package_manifest_test.rs
+++ b/tests/package_manifest_test.rs
@@ -24,7 +24,8 @@ fn development_only_files_are_excluded_from_package() {
                     "tests/ci_workflow_policy_test.rs",
                     "tests/mutation_ci_scope_test.rs",
                     "tests/mutation_scripts_test.rs",
-                    "tests/mutation_transport_scripts_test.rs"
+                    "tests/mutation_transport_scripts_test.rs",
+                    "tests/package_manifest_test.rs"
                 ]
                 .iter()
                 .any(|prefix| path.starts_with(prefix)),


### PR DESCRIPTION
Prepare v0.11.3 for the client lifecycle, manual tool-result, image-validation, and token-estimation fixes merged in #21. Synchronize Cargo metadata, installation instructions, the changelog, and the developer guide; public signatures and defaults remain unchanged.

Unpacked-crate validation also found that the repository's package-content test tried to repackage Cargo-generated files. Exclude that repository-only test from the archive and extend its existing exclusion assertion. The regression fails before the manifest fix and passes afterward.

Validation: all 356 active repository tests passed (3 intentionally ignored), formatting and all-target/all-feature Clippy passed, and all four /simplify review angles were clean. The clean 104-file crate archive builds and passes all 337 packaged tests (3 intentionally ignored); its embedded VCS metadata matches the release commit. CI runs before publishing.
